### PR TITLE
Use `gen_num_blocks` instead of `count3` in reduce

### DIFF
--- a/spark_benchmark_hpc.py
+++ b/spark_benchmark_hpc.py
@@ -144,7 +144,7 @@ def main():
     timers.stop("average")
 
     timers.init_and_start("reduce")
-    result = C.reduce(lambda x, y: x + y) / count3
+    result = C.reduce(lambda x, y: x + y) / gen_num_blocks
     timers.stop("reduce")
     timers.stop("overall")
 


### PR DESCRIPTION
`count3` is only defined if not `lazy`.
This commit uses `gen_num_blocks` to divide the total value for the average,
and makes it run if lazy is set.